### PR TITLE
up json payload limit to 50mb

### DIFF
--- a/template/node10-express-armhf/index.js
+++ b/template/node10-express-armhf/index.js
@@ -9,7 +9,9 @@ const handler = require('./function/handler');
 const bodyParser = require('body-parser')
 
 // app.use(bodyParser.urlencoded({ extended: false }));
-app.use(bodyParser.json());
+app.use(bodyParser.json({
+    limit: '50mb'
+}));
 app.use(bodyParser.raw());
 app.use(bodyParser.text({ type : "text/*" }));
 app.disable('x-powered-by');

--- a/template/node10-express/index.js
+++ b/template/node10-express/index.js
@@ -9,7 +9,9 @@ const handler = require('./function/handler');
 const bodyParser = require('body-parser')
 
 // app.use(bodyParser.urlencoded({ extended: false }));
-app.use(bodyParser.json());
+app.use(bodyParser.json({
+	limit: '50mb'
+}));
 app.use(bodyParser.raw());
 app.use(bodyParser.text({ type : "text/*" }));
 app.disable('x-powered-by');


### PR DESCRIPTION
We were getting payload too large errors on agreement function invocations. This bumps payload size up to 50mb